### PR TITLE
Fixed incorrect class name for hbs2

### DIFF
--- a/addon/components/code-example.hbs
+++ b/addon/components/code-example.hbs
@@ -4,7 +4,7 @@
       <div class="code-example-tab {{if (eq this.activeTab "hbs") 'active'}}" role="button" {{on "click" (set this "activeTab" "hbs")}}>Template</div>
     {{/if}}
     {{#if @hbs2}}
-      <div class="code-sample-tab {{if (eq this.activeTab "hbs2") 'active'}}" role="button" {{on "click" (set this "activeTab" "hbs2")}}>Template 2</div>
+      <div class="code-example-tab {{if (eq this.activeTab "hbs2") 'active'}}" role="button" {{on "click" (set this "activeTab" "hbs2")}}>Template 2</div>
     {{/if}}
     {{#if @js}}
       <div class="code-example-tab {{if (eq this.activeTab "js") 'active'}}" role="button" {{on "click" (set this "activeTab" "js")}}>Javascript</div>


### PR DESCRIPTION
This would fix the incorrect display on the fourth example in the [ember-power-select docs](https://ember-power-select.com/docs/the-trigger)!